### PR TITLE
Change `bs4` to `beautifulsoup4` in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         'Click',
         'boto3',
         'requests',
-        'bs4',
+        'beautifulsoup4',
         'configparser',
         'enum-compat'
     ],


### PR DESCRIPTION
I had some strange behavior trying to install this: it looks like the bs4 link installs an older version of BeautifulSoup (4.4.3?) which won't work correctly. Using `beautifulsoup4` pulls the latest version.
Note: should probably tell the bs4 maintainers to update that alias.